### PR TITLE
Remove oneliners, improved readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You cannot deconstruct the package due to how it's coded, You need to require an
 
 ## Command Based Endpoints
 
-## Achievement
+### Achievement
 
 ```javascript
 const Idiot = require("idiotic-api");
@@ -19,7 +19,7 @@ await message.channel.send(new MessageAttachment(
 	"achievement.png"));
 ```
 
-## Bat Slap
+### Bat Slap
 
 ```javascript
 const Idiot = require("idiotic-api");
@@ -31,7 +31,7 @@ await message.channel.send(new MessageAttachment(
 	"batslap.png"));
 ```
 
-## Wanted
+### Wanted
 
 ```javascript
 const Idiot = require("idiotic-api");
@@ -42,7 +42,7 @@ await message.channel.send(new MessageAttachment(
 	"batslap.png"));
 ```
 
-## pls
+### pls
 
 ```javascript
 const Idiot = require("idiotic-api");
@@ -55,7 +55,7 @@ await message.channel.send(new MessageAttachment(
 
 ## Greeting/Farewell Based Endpoints
 
-## Gearz Welcome
+### Gearz Welcome
 
 ```javascript
 const Idiot = require("idiotic-api");

--- a/README.md
+++ b/README.md
@@ -10,43 +10,59 @@ You cannot deconstruct the package due to how it's coded, You need to require an
 
 ## Achievement
 
-```js
+```javascript
 const Idiot = require("idiotic-api");
 const API = new Idiot.Client("your-token-here");
-await message.channel.send({ files: [{ attachment: await API.achievement(message.author.displayAvatarURL({format:"png", size:32}), args.join(" ")), name: "achievement.png" }] });
+
+await message.channel.send(new MessageAttachment(
+	await API.achievement(message.author.displayAvatarURL({format:"png", size:32}), args.join(" ")),
+	"achievement.png"));
 ```
 
 ## Bat Slap
 
-```js
+```javascript
 const Idiot = require("idiotic-api");
 const API = new Idiot.Client("your-token-here");
-await message.channel.send({ files: [{ attachment: await API.batslap(message.author.displayAvatarURL({format:"png", size:128}), message.mentions.users.first().displayAvatarURL({format:"png", size:128})), name: "batslap.png" }] });
+
+await message.channel.send(new MessageAttachment(
+	await API.batslap(message.author.displayAvatarURL({format:"png", size:128}),
+		message.mentions.users.first().displayAvatarURL({format:"png", size:128})),
+	"batslap.png"));
 ```
 
 ## Wanted
 
-```js
+```javascript
 const Idiot = require("idiotic-api");
 const API = new Idiot.Client("your-token-here");
-await message.channel.send({ files: [{ attachment: await API.wanted(message.author.displayAvatarURL({format:"png", size:128})), name: "wanted.png" }] });
+
+await message.channel.send(new MessageAttachment(
+	await API.wanted(message.author.displayAvatarURL({format:"png", size:128})),
+	"batslap.png"));
 ```
 
 ## pls
 
-```js
+```javascript
 const Idiot = require("idiotic-api");
 const API = new Idiot.Client("your-token-here");
-await message.channel.send({ files: [{ attachment: await API.pls((message.mentions.members.first() || message.member).displayName), name: "pls.png" }] });
+
+await message.channel.send(new MessageAttachment(
+	await API.pls((message.mentions.members.first() || message.member).displayName),
+	"pls.png"));
 ```
 
 ## Greeting/Farewell Based Endpoints
 
 ## Gearz Welcome
 
-```js
+```javascript
 const Idiot = require("idiotic-api");
 const API = new Idiot.Client("your-token-here");
-const user = member.user;
-await message.channel.send({ files: [{ attachment: await API.welcome("gearz", user.bot, user.tag,`${member.guild.name}#${member.guild.memberCount}`), name: "pls.png" }] });
+const { user } = member;
+
+await message.channel.send(new MessageAttachment(
+	await API.welcome("gearz", user.bot, user.tag,`${member.guild.name}#${member.guild.memberCount}`),
+	"welcome"));
 ```


### PR DESCRIPTION
The README.md file was too cluttered with these oneliners and are very hard to follow (remember that in NPM, the font is bigger than in Github's). This PR changes the codeblocks to have less than 120 columns length (average of 80) so it can be read better. It also implements the usage of [MessageAttachment](https://discord.js.org/#/docs/main/master/class/MessageAttachment)